### PR TITLE
Add mpp-spl to Solana payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ MPP is payment-method agnostic. Each chain/rail has its own plugin:
 - [@dexterai/mpp](https://github.com/Dexter-DAO/dexter-mpp) - Managed settlement (no blockchain infra needed).
 - [mpp-solana](https://github.com/starc007/mpp-solana) - SPL token support.
 - [mppx-solana](https://github.com/nitishxyz/mppx-solana) - mppx plugin for Solana.
+- [mpp-spl](https://github.com/nullxnothing/mpp-spl) - SPL token + pump.fun payment layer. Token registry, Jupiter/bonding curve pricing, charge config resolver. ![Stars](https://img.shields.io/github/stars/nullxnothing/mpp-spl)
 
 ### Lightning
 


### PR DESCRIPTION
Adds [mpp-spl](https://github.com/nullxnothing/mpp-spl) under the Solana payment methods section.

SPL token + pump.fun payment layer for MPP. Includes token registry, Jupiter Price API v3 + bonding curve price providers, and a charge config resolver that maps directly to `@solana/mpp`. First community tooling for the Solana MPP SDK.

- GitHub: https://github.com/nullxnothing/mpp-spl
- 85 tests, zero runtime deps, MIT