### PR TITLE
Add x402-proxy to Agent Tools & CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Community:
 - [MPP-Inspector](https://github.com/amgb20/MPP-Inspector) - CLI + web dashboard for debugging MPP flows. "Postman for MPP."
 - [mcp-protocol-tester](https://github.com/whiteknightonhorse/mcp-protocol-tester) - Universal test suite for MCP servers with dual-rail payment testing (x402 + MPP).
 - [openprice](https://github.com/tldr-wknd/openprice) - Price discovery middleware for the agent economy.
+- [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 and MPP paid APIs. Auto-pays HTTP 402 responses on Base, Solana, and Tempo. MCP stdio proxy for AI agents, wallet management, pay-per-token streaming via MPP sessions. `npx x402-proxy`. ([npm](https://www.npmjs.com/package/x402-proxy))
 
 ## Middleware & Extensions
 


### PR DESCRIPTION
## Add x402-proxy

**What:** `curl` for x402 and MPP paid APIs. Auto-pays HTTP 402 responses on Base, Solana, and Tempo. Includes MCP stdio proxy for AI agents, wallet management, and pay-per-token streaming via MPP sessions.

**Why:** x402-proxy is the only CLI that handles both x402 and MPP payment flows in a single tool, letting agents and developers consume any paid API without writing payment code. Published on npm (`npx x402-proxy`), actively maintained.

- GitHub: https://github.com/cascade-protocol/x402-proxy
- npm: https://www.npmjs.com/package/x402-proxy

**Category:** Agent Tools & CLIs