### PR TITLE
Add Surf to Services (First-Party)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Services with built-in MPP payment support:
 - [APIMesh](https://github.com/mbeato/conway) - 23 pay-per-call APIs for AI agents (email-verify, tech-stack, mock-jwt-generator, email-security, robots-txt-parser, web-checker, +17 more). Supports x402 + MPP.
 - [paid-image-api](https://github.com/cepuyut/paid-image-api) - Pay-per-request AI image generation on Tempo.
 - [Dtelecom](https://github.com/dteIecom/Dtelecom) - Real-time voice, video & voice AI. Pay-per-use via x402/MPP.
+- [Surf](https://surf.cascade.fyi) - Pay-per-use Twitter, Reddit, web, and inference APIs for AI agents. Dual-protocol (x402 + MPP) on Base, Solana, and Tempo. Unified MCP server at `/mcp`. ([GitHub](https://github.com/cascade-protocol/surf))
 
 ### Proxied (via mpp.tempo.xyz)
 


### PR DESCRIPTION
## Add Surf

**What:** Pay-per-use Twitter, Reddit, web search/crawl, and inference APIs for AI agents. Dual-protocol (x402 + MPP) on Base, Solana, and Tempo. Unified MCP server with tool filtering.

**Why:** Surf is a live, production service accepting MPP payments with native charge and session support (streaming inference via MPP sessions). Bundles four data domains under a single payment surface - no signup or API keys needed.

- Site: https://surf.cascade.fyi
- GitHub: https://github.com/cascade-protocol/surf

**Category:** Services > First-Party (native MPP)