### PR TITLE
Add Gradience Wallet to Payment Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ MPP is payment-method agnostic. Each chain or rail has its own plugin.
 - [mpp-abstract](https://github.com/Abstract-Foundation/mpp-abstract) - Abstract chain with custom intents and escrow.
 - [mpp-movement](https://github.com/MoveIndustries/mpp-movement) - Movement Network payment method.
 - [mpp-ton](https://github.com/TesseraeVentures/mpp-ton) - TON payment method for MPP.
+- [gradience-wallet](https://github.com/DaviRain-Su/gradience-wallet) - Agent wallet orchestration platform with MPP charge and session support for BSC, Conflux (eSpace + Core), XLayer, TON, Solana, Base, Arbitrum, Polygon, and Optimism.
 - [algorand-mpp-sdk](https://github.com/GoPlausible/algorand-mpp-sdk) - Algorand payment method for MPP.
 - [mpp-avalanche](https://github.com/ashucoder9/mpp-avalanche) - Avalanche with streaming payment channels.
 - [mppx-multiversx](https://github.com/sasurobert/mppx-multiversx) - MultiversX payment method for MPP.

--- a/registry.json
+++ b/registry.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-04-08T10:19:35.704Z",
-  "total_projects": 286,
+  "generated_at": "2026-04-09T01:20:44.253Z",
+  "total_projects": 287,
   "categories": [
     {
       "name": "Protocol and Specs",
@@ -226,6 +226,12 @@
               "name": "mpp-ton",
               "url": "https://github.com/TesseraeVentures/mpp-ton",
               "description": "TON payment method for MPP",
+              "type": "github"
+            },
+            {
+              "name": "gradience-wallet",
+              "url": "https://github.com/DaviRain-Su/gradience-wallet",
+              "description": "Agent wallet orchestration platform with MPP charge and session support for BSC, Conflux (eSpace + Core), XLayer, TON, Solana, Base, Arbitrum, Polygon, and Optimism",
               "type": "github"
             },
             {


### PR DESCRIPTION
Adds [Gradience Wallet](https://github.com/DaviRain-Su/gradience-wallet) to the Payment Methods \> Other Chains section.

Gradience is an agent wallet orchestration platform with MPP charge and session support across 11 chains:
- BSC, Conflux (eSpace + Core), XLayer
- TON, Solana
- Base, Arbitrum, Polygon, Optimism
- Tempo

Also ran Registry generated: 287 projects across 11 categories
Output: /private/tmp/awesome-mpp/registry.json to update .