### PR TITLE
Add C2PAVerify to First-Party services

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Services with built-in MPP payment support:
 - [Surf](https://surf.cascade.fyi) - Pay-per-use Twitter, Reddit, web, and inference APIs for AI agents with dual-protocol support on Base, Solana, and Tempo.
 - [AgentMail](https://agentmail.to) - Email inboxes for AI agents.
 - [Browserbase](https://browserbase.com) - Headless browser sessions, web search, and page fetching for AI agents.
+- [C2PAVerify](https://c2pa.mppfy.com) - Verify C2PA (Content Provenance and Authenticity) manifests on images, video, and audio. Extracts embedded manifest, validates signature chain against the CAI trust list, returns structured provenance report.
 - [Dune](https://dune.com) - Query raw transaction data, decoded smart contract events, stablecoin flows, and protocol analytics.
 - [Judge0](https://judge0.com) - Online code execution in 60+ programming languages with sandboxed isolation.
 - [Modal](https://modal.com) - Serverless GPU compute for sandboxed code execution and AI/ML workloads.


### PR DESCRIPTION
Adds **C2PAVerify** to the First-Party services list.

- **Service:** https://c2pa.mppfy.com
- **Source:** https://github.com/mppfy/C2PAVerify

### What it does

C2PA (Content Provenance and Authenticity) manifest verification on images, video, and audio. Extracts embedded manifest, validates signature chain against the [CAI trust list](https://contentcredentials.org/trust/) (27 anchors + 114 end-entity certs bundled), returns structured provenance report with `trust_chain` classification (`valid` | `partial` | `unknown`).

Powered by [c2pa-rs](https://github.com/contentauth/c2pa-rs) compiled to WASM, running on Cloudflare Workers.

### MPP support

- Method: `tempo` (Tempo mainnet)
- Currency: USDC.e (`0x20c0…e8b50`)
- Price: 0.01 USDC.e per `POST /verify` call
- OpenAPI 3.1 discovery: https://c2pa.mppfy.com/openapi.json

### Checklist

- [x] Proper link format: `- [Name](URL) - Description.`
- [x] Alphabetically positioned (C, after Browserbase)
- [x] Service is live and returns MPP 402 WWW-Authenticate challenge
- [x] First-party MPP support (not a proxy)