### PR TITLE
Add Hive Civilization to Middleware and Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The mppx TypeScript SDK includes built-in middleware for Hono, Express, Next.js,
 - [@x402/evm](https://github.com/x402-foundation/x402) - X402 Payment Protocol EVM Implementation.
 - [@suimpp/mpp](https://github.com/mission69b/suimpp) - Sui USDC payment method for the Machine Payments Protocol (MPP).
 - [auditor-mcp](https://github.com/xaviersharwin10/soroban_node_0) - MCP server that audits Soroban smart contracts via autonomous x402 / Stripe MPP payments on Stellar Testnet.
+- [Hive Civilization](https://thehiveryiq.com) - DID-federated trust score, Spectral receipts, and identity passport for MPP-paying agents. Composes with mppx via Express middleware. Rail-agnostic: x402 and MPP both accepted on same routes.
 ## Services
 
 ### First-Party


### PR DESCRIPTION
[Hive Civilization](https://thehiveryiq.com) — DID-federated trust score, Spectral receipts, and identity passport for MPP-paying agents.

Adds Hive to the **Middleware and Extensions** section, alongside @moltrust/mpp, costillery, agentlair-mpp-identity-bridge, and agent-verifier — all of which Hive composes with rather than competes against.

Hive's position in the taxonomy: trust/receipt/identity composition layer for any payment rail. The same pattern Hive runs for x402 (since 2026-04-29) now runs for MPP — both rails accepted on the same routes, Spectral receipts emitted regardless of which rail paid.

## Live endpoints (smoke-tested 2026-04-29)

- `https://hivetrust.onrender.com` — DID-federated trust score, identity passport, KYA verification
- `https://hive-mcp-identity.onrender.com` — W3C DID resolution, agent KYC, attestation management

Both registered with [MPPScan](https://www.mppscan.com) (auto-discovery, confirmed 2026-04-29T19:14:34Z).

## Checklist

- [x] Project is actively maintained (commits 2026-04-29)
- [x] Project is related to MPP
- [x] Description follows `[Name](URL) - Description.` format
- [x] No self-promotion language, no first-person
- [x] Single-line entry placed at end of Middleware and Extensions section