### PR TITLE
Add VirtualSMS x402 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Services with built-in MPP payment support:
 - [ScreenshotOne](https://screenshotone.com) - Website screenshot API for capturing any URL as PNG, JPEG, WebP, or PDF.
 - [Billboard](https://x.com/MPPBillboard) - Post to @MPPBillboard on X with dynamic pricing that doubles per post.
 - [Clado](https://clado.ai) - People search, LinkedIn enrichment, and deep research for lead generation.
+- [VirtualSMS](https://virtualsms.io) - Pay-per-use SMS verification via x402 on Base and Solana. Real-carrier numbers across 145+ countries and 2,500+ services from $0.05/code, with deposit-based balance and an MCP server for AI agents.
 
 ### Proxied via Tempo
 


### PR DESCRIPTION
Adds VirtualSMS to **Services > First-Party**.

VirtualSMS is a pay-per-use SMS verification API gated by x402. Real-carrier (non-VoIP) numbers across 145+ countries and 2,500+ services. Settles in USDC on Base and USDC/USDT on Solana, deposit-based balance.

- Site: https://virtualsms.io
- x402 manifest: https://virtualsms.io/api/v1/x402/info
- MCP server (for AI agents): https://github.com/virtualsms-io/mcp-server
- Pricing: from $0.05/code, $2 minimum deposit
- Status: live in production

Format follows CONTRIBUTING.md (single-dash list item, period at end), appended at the bottom of the First-Party section. One entry, no other changes. Happy to adjust wording or move category if you prefer.