### PR TITLE
Add StockWaves and 402Sentinel to First-Party services

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Services with built-in MPP payment support:
 - [ScreenshotOne](https://screenshotone.com) - Website screenshot API for capturing any URL as PNG, JPEG, WebP, or PDF.
 - [Billboard](https://x.com/MPPBillboard) - Post to @MPPBillboard on X with dynamic pricing that doubles per post.
 - [Clado](https://clado.ai) - People search, LinkedIn enrichment, and deep research for lead generation.
+- [StockWaves](https://stockwaves.net) - China & global market intelligence (real-time Weibo/Baidu/Douyin pulse, structured CN news/events, theme momentum), cross-asset quant signals (A-share/HK/US equities, crypto, macro), and a tokenized-stock pre-trade safety gate for AI agents. Flagship cross-asset decision brief accepts native MPP + x402; settles USDC on Base.
+- [402Sentinel](https://402sentinel.com) - Pre-payment counterparty-risk scoring, buyer-side payment firewall (routing/amount/velocity + prompt-injection + intent-mismatch), OFAC/FATF compliance screening, and tokenized-RWA token safety checks for agent payments. Risk gate accepts native MPP + x402; settles USDC on Base.
 
 ### Proxied via Tempo
 


### PR DESCRIPTION
Two live, MPP-accepting services for the First-Party list:

- **[StockWaves](https://stockwaves.net)** — China & global market data, cross-asset quant signals, and a tokenized-stock pre-trade safety gate for AI agents. The flagship cross-asset decision brief accepts native MPP (mppx `evm` charge) alongside x402; settles USDC on Base.
- **[402Sentinel](https://402sentinel.com)** — pre-payment counterparty-risk + buyer-side payment firewall + OFAC/FATF compliance + tokenized-RWA token safety checks for agent payments. The risk gate accepts native MPP alongside x402; settles USDC on Base.

Both are live and accepting MPP payments today (verified end-to-end: the 402 advertises a `www-authenticate: Payment` challenge and settles via the Coinbase/CDP facilitator). Entries added to the bottom of the First-Party section; `[Name](URL) - Description.` format.